### PR TITLE
Feature  metada

### DIFF
--- a/src/AsYouLikeIt.FileProvider.Tests/FileServiceTest.cs
+++ b/src/AsYouLikeIt.FileProvider.Tests/FileServiceTest.cs
@@ -53,7 +53,9 @@ namespace AsYouLikeIt.FileProvider.Tests
 
     public abstract class FileServiceTest
     {
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
         protected IFileService _fileService;
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
 
         //protected abstract IServiceProvider GetServiceProvider();
 
@@ -353,36 +355,20 @@ namespace AsYouLikeIt.FileProvider.Tests
 
             // check the metadata for each file
             
-            // check full path
-            Assert.True(files[0].FullPath.EndsWith(Format.PathMergeForwardSlashes(directoryPath, "bytes.bin")),
+            // check absolute directory path
+            Assert.True(files[0].AbsoluteDirectoryPath.EqualsCaseInsensitive(directoryPath.StripAllLeadingAndTrailingSlashes()),
+                $"AbsoluteDirectoryPath should be '{directoryPath}' for file '{files[0].FileName}'");
+            Assert.True(files[1].AbsoluteDirectoryPath.EqualsCaseInsensitive(directoryPath.StripAllLeadingAndTrailingSlashes()),
+                $"AbsoluteDirectoryPath should be '{directoryPath}' for file '{files[1].FileName}'");
+            Assert.True(files[2].AbsoluteDirectoryPath.EqualsCaseInsensitive(directoryPath.StripAllLeadingAndTrailingSlashes()),
+                $"AbsoluteDirectoryPath should be '{directoryPath}' for file '{files[2].FileName}'");
+
+            // check absolute paths
+            Assert.True(files[0].AbsoluteFilePath == Format.PathMergeForwardSlashes(directoryPath, "bytes.bin"),
                 $"FullPath should equal '{Format.PathMergeForwardSlashes(directoryPath, "bytes.bin")}'");
-            Assert.True(files[1].FullPath.EndsWith(Format.PathMergeForwardSlashes(directoryPath, "bytes2.bin")),
+            Assert.True(files[1].AbsoluteFilePath == Format.PathMergeForwardSlashes(directoryPath, "bytes2.bin"),
                 $"FullPath should equal '{Format.PathMergeForwardSlashes(directoryPath, "bytes2.bin")}'");
-            Assert.True(files[2].FullPath.EndsWith(Format.PathMergeForwardSlashes(directoryPath, "bytes3.bin")),
-                $"FullPath should equal '{Format.PathMergeForwardSlashes(directoryPath, "bytes3.bin")}'");
-
-            // check the full directory path
-            foreach (var f in files)
-            {
-                // Ensure the full directory path is correct
-                Assert.True(f.FullDirectoryPath.Contains(Format.PathMergeForwardSlashes(directoryPath)),
-                    $"FullDirectoryPath should be '{Format.PathMergeForwardSlashes(directoryPath)}' for file '{f.FileName}'");
-            }
-
-            // check relative directory path
-            Assert.True(files[0].RelativeDirectoryPath.EqualsCaseInsensitive(directoryPath),
-                $"RelativeDirectoryPath should be '{directoryPath}' for file '{files[0].FileName}'");
-            Assert.True(files[1].RelativeDirectoryPath.EqualsCaseInsensitive(directoryPath),
-                $"RelativeDirectoryPath should be '{directoryPath}' for file '{files[1].FileName}'");
-            Assert.True(files[2].RelativeDirectoryPath.EqualsCaseInsensitive(directoryPath),
-                $"RelativeDirectoryPath should be '{directoryPath}' for file '{files[2].FileName}'");
-
-            // check relative path
-            Assert.True(files[0].RelativeFilePath == Format.PathMergeForwardSlashes(directoryPath, "bytes.bin"),
-                $"FullPath should equal '{Format.PathMergeForwardSlashes(directoryPath, "bytes.bin")}'");
-            Assert.True(files[1].RelativeFilePath == Format.PathMergeForwardSlashes(directoryPath, "bytes2.bin"),
-                $"FullPath should equal '{Format.PathMergeForwardSlashes(directoryPath, "bytes2.bin")}'");
-            Assert.True(files[2].RelativeFilePath == Format.PathMergeForwardSlashes(directoryPath, "bytes3.bin"),
+            Assert.True(files[2].AbsoluteFilePath == Format.PathMergeForwardSlashes(directoryPath, "bytes3.bin"),
                 $"FullPath should equal '{Format.PathMergeForwardSlashes(directoryPath, "bytes3.bin")}'");
 
             // check file sizes

--- a/src/AsYouLikeIt.FileProvider.Tests/FileServiceTest.cs
+++ b/src/AsYouLikeIt.FileProvider.Tests/FileServiceTest.cs
@@ -394,9 +394,6 @@ namespace AsYouLikeIt.FileProvider.Tests
             await _fileService.DeleteDirectoryAndContentsAsync(directoryPath);
         }
 
-
-
-
         #region helpers
 
         public byte[] GenerateRandomBytes(int bytes = 256)

--- a/src/AsYouLikeIt.FileProvider.Tests/FileServiceTest.cs
+++ b/src/AsYouLikeIt.FileProvider.Tests/FileServiceTest.cs
@@ -391,6 +391,13 @@ namespace AsYouLikeIt.FileProvider.Tests
                     $"FileExtension should be '{expectedExtension}' for file '{f.FileName}'");
             }
 
+            foreach(var f in files)
+            {
+                var individualFile = await _fileService.GetFileMetadataAsync(f.AbsoluteFilePath);
+                Assert.True(f.FileName == individualFile.FileName,
+                    $"The file name '{f.FileName}' from ListFilesWithMetadataAsync should match the file name '{individualFile.FileName}' from GetFileMetadataAsync");
+            }
+
             await _fileService.DeleteDirectoryAndContentsAsync(directoryPath);
         }
 

--- a/src/AsYouLikeit.FileProvider/AsYouLikeit.FileProviders.csproj
+++ b/src/AsYouLikeit.FileProvider/AsYouLikeit.FileProviders.csproj
@@ -9,7 +9,7 @@
 		<Copyright>Copyright © $([System.DateTime]::Now.Year)</Copyright>
 		<Trademark></Trademark>
 		<Product>$(Title)</Product>
-		<VersionPrefix>1.2.2.2-beta</VersionPrefix>
+		<VersionPrefix>1.2.3.0-beta</VersionPrefix>
 		<Description>
 			Provides DI for multiple file providers allowing applications to access files from virtual locations.
 			Can be extended to add implementations for AWS and other cloud providers.
@@ -18,6 +18,7 @@
 			- Normal file system
 			- Azure Blob Storage
 			- List file names in a directory
+			- List file metadata in a directory
 		</Description>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<PackageProjectUrl></PackageProjectUrl>

--- a/src/AsYouLikeit.FileProvider/EnvironmentContext.cs
+++ b/src/AsYouLikeit.FileProvider/EnvironmentContext.cs
@@ -5,6 +5,6 @@ namespace AsYouLikeIt.FileProviders
     {
         public string ContentRootPath { get; set; }
 
-        public bool UseForwardSlashed { get; set; }
+        public bool UseForwardSlashes { get; set; }
     }
 }

--- a/src/AsYouLikeit.FileProvider/FileMetdataBase.cs
+++ b/src/AsYouLikeit.FileProvider/FileMetdataBase.cs
@@ -10,9 +10,9 @@ namespace AsYouLikeit.FileProviders
       
         public string FullDirectoryPath { get; set; }
 
-        public string RelativeDirectoryPath { get; set; }
+        public string AbsoluteDirectoryPath { get; set; }
 
-        public string RelativeFilePath { get; set; }
+        public string AbsoluteFilePath { get; set; }
 
         public string FileName { get; set; }
 

--- a/src/AsYouLikeit.FileProvider/FileMetdataBase.cs
+++ b/src/AsYouLikeit.FileProvider/FileMetdataBase.cs
@@ -6,10 +6,6 @@ namespace AsYouLikeit.FileProviders
 {
     public partial class FileMetdataBase : IFileMetadata
     {
-        public string FullPath { get; set; }
-      
-        public string FullDirectoryPath { get; set; }
-
         public string AbsoluteDirectoryPath { get; set; }
 
         public string AbsoluteFilePath { get; set; }

--- a/src/AsYouLikeit.FileProvider/FileMetdataBase.cs
+++ b/src/AsYouLikeit.FileProvider/FileMetdataBase.cs
@@ -8,14 +8,20 @@ namespace AsYouLikeit.FileProviders
     {
         public string FullPath { get; set; }
       
-        public string DirectoryPath { get; set; }
-  
+        public string FullDirectoryPath { get; set; }
+
+        public string RelativeDirectoryPath { get; set; }
+
+        public string RelativeFilePath { get; set; }
+
         public string FileName { get; set; }
-   
+
+        public string Extension { get; set; }
+
         public long Size { get; set; }
    
         public DateTimeOffset LastModified { get; set; }
  
-        public IDictionary<string, string> MetaData { get; set; } = new Dictionary<string, string>(StringComparer.Ordinal);
+        public IDictionary<string, string> Metadata { get; set; } = new Dictionary<string, string>(StringComparer.Ordinal);
     }
 }

--- a/src/AsYouLikeit.FileProvider/FileMetdataBase.cs
+++ b/src/AsYouLikeit.FileProvider/FileMetdataBase.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AsYouLikeit.FileProviders
+{
+    public partial class FileMetdataBase : IFileMetadata
+    {
+        public string FullPath { get; set; }
+      
+        public string DirectoryPath { get; set; }
+  
+        public string FileName { get; set; }
+   
+        public long Size { get; set; }
+   
+        public DateTimeOffset LastModified { get; set; }
+ 
+        public IDictionary<string, string> MetaData { get; set; } = new Dictionary<string, string>(StringComparer.Ordinal);
+    }
+}

--- a/src/AsYouLikeit.FileProvider/IFileMetadata.cs
+++ b/src/AsYouLikeit.FileProvider/IFileMetadata.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Metadata = System.Collections.Generic.IDictionary<string, string>;
+
+namespace AsYouLikeit.FileProviders
+{
+    public interface IFileMetadata
+    {
+        /// <summary>
+        /// Gets or sets the full path of the file, including the file name.
+        /// </summary>
+        string FullPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the directory path where the file is located.
+        /// </summary>
+        string DirectoryPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the file name.
+        /// </summary>
+        string FileName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the size of the file in bytes.
+        /// </summary>
+        long Size { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date and time when the file was last modified.
+        /// </summary>
+        DateTimeOffset LastModified { get; set; }
+
+        /// <summary>
+        /// Gets or sets the metadata associated with the file.
+        /// </summary>
+        Metadata MetaData { get; set; }
+    }
+}

--- a/src/AsYouLikeit.FileProvider/IFileMetadata.cs
+++ b/src/AsYouLikeit.FileProvider/IFileMetadata.cs
@@ -7,15 +7,15 @@ namespace AsYouLikeit.FileProviders
 {
     public interface IFileMetadata
     {
-        /// <summary>
-        /// Gets or sets the full path of the file, including the file name.
-        /// </summary>
-        string FullPath { get; set; }
+        ///// <summary>
+        ///// Gets or sets the full path of the file, including the file name.
+        ///// </summary>
+        //string FullPath { get; set; }
 
-        /// <summary>
-        /// Gets or sets the directory path where the file is located.
-        /// </summary>
-        string FullDirectoryPath { get; set; }
+        ///// <summary>
+        ///// Gets or sets the directory path where the file is located.
+        ///// </summary>
+        //string FullDirectoryPath { get; set; }
 
         /// <summary>
         /// Gets or sets the relative path of the file from the base directory. This is typically used for storage or display purposes.

--- a/src/AsYouLikeit.FileProvider/IFileMetadata.cs
+++ b/src/AsYouLikeit.FileProvider/IFileMetadata.cs
@@ -7,15 +7,6 @@ namespace AsYouLikeit.FileProviders
 {
     public interface IFileMetadata
     {
-        ///// <summary>
-        ///// Gets or sets the full path of the file, including the file name.
-        ///// </summary>
-        //string FullPath { get; set; }
-
-        ///// <summary>
-        ///// Gets or sets the directory path where the file is located.
-        ///// </summary>
-        //string FullDirectoryPath { get; set; }
 
         /// <summary>
         /// Gets or sets the relative path of the file from the base directory. This is typically used for storage or display purposes.

--- a/src/AsYouLikeit.FileProvider/IFileMetadata.cs
+++ b/src/AsYouLikeit.FileProvider/IFileMetadata.cs
@@ -20,12 +20,12 @@ namespace AsYouLikeit.FileProviders
         /// <summary>
         /// Gets or sets the relative path of the file from the base directory. This is typically used for storage or display purposes.
         /// </summary>
-        string RelativeDirectoryPath { get; set; }
+        string AbsoluteDirectoryPath { get; set; }
 
         /// <summary>
         /// Gets or sets the relative file path from the base directory. This is typically used for storage or display purposes.
         /// </summary>
-        string RelativeFilePath { get; set; }
+        string AbsoluteFilePath { get; set; }
 
         /// <summary>
         /// Gets or sets the file name.

--- a/src/AsYouLikeit.FileProvider/IFileMetadata.cs
+++ b/src/AsYouLikeit.FileProvider/IFileMetadata.cs
@@ -15,12 +15,27 @@ namespace AsYouLikeit.FileProviders
         /// <summary>
         /// Gets or sets the directory path where the file is located.
         /// </summary>
-        string DirectoryPath { get; set; }
+        string FullDirectoryPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the relative path of the file from the base directory. This is typically used for storage or display purposes.
+        /// </summary>
+        string RelativeDirectoryPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the relative file path from the base directory. This is typically used for storage or display purposes.
+        /// </summary>
+        string RelativeFilePath { get; set; }
 
         /// <summary>
         /// Gets or sets the file name.
         /// </summary>
         string FileName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the file extension (e.g., ".txt", ".jpg"). This is typically used for file type identification and handling.
+        /// </summary>
+        string Extension { get; set; }
 
         /// <summary>
         /// Gets or sets the size of the file in bytes.
@@ -35,6 +50,6 @@ namespace AsYouLikeit.FileProviders
         /// <summary>
         /// Gets or sets the metadata associated with the file.
         /// </summary>
-        Metadata MetaData { get; set; }
+        Metadata Metadata { get; set; }
     }
 }

--- a/src/AsYouLikeit.FileProvider/Services/AzureBlobFileService.cs
+++ b/src/AsYouLikeit.FileProvider/Services/AzureBlobFileService.cs
@@ -100,13 +100,14 @@ namespace AsYouLikeIt.FileProviders.Services
 
             await foreach (var blobHierarchyItem in blobContainerClient.GetBlobsByHierarchyAsync(prefix: prefix, delimiter: "/"))
             {
+
+                throw new NotImplementedException("Need to update values");
+
                 if (!blobHierarchyItem.IsPrefix)
                 {
                     var fileName = blobHierarchyItem.Blob.Name.Substring(blobPath.Path.Length).StripAllLeadingAndTrailingSlashes();
                     var file = new FileMetdataBase
                     {
-                        FullPath = Format.PathMergeForwardSlashes(blobPath.ContainerName, blobPath.Path, fileName), // full path of the file
-                        FullDirectoryPath = Format.PathMergeForwardSlashes(blobPath.ContainerName, blobPath.Path),//Format.PathMergeForwardSlashes( blobPath. blobHierarchyItem.Blob.Name.Substring(0, blobHierarchyItem.Blob.Name.LastIndexOf('/')).StripAllLeadingAndTrailingSlashes(), // directory path
                         AbsoluteDirectoryPath = Format.PathMergeForwardSlashes(blobPath.ContainerName, blobPath.Path), // relative directory path from the base directory (for display/storage purposes)
                         AbsoluteFilePath = Format.PathMergeForwardSlashes(blobPath.ContainerName, blobPath.Path, fileName),
                         FileName = fileName,
@@ -115,6 +116,9 @@ namespace AsYouLikeIt.FileProviders.Services
                         Extension = GetFileExtenstion(blobHierarchyItem.Blob.Name.Substring(blobPath.Path.Length)),// file extension
 
                     };
+
+                    // add metadata if available
+
                     files.Add(file);
                 }
             }
@@ -135,12 +139,12 @@ namespace AsYouLikeIt.FileProviders.Services
                 blobPath.Path.LastIndexOf('/') > 0 ? blobPath.Path.LastIndexOf('/') : 0)
                 .StripAllLeadingAndTrailingSlashes();
 
+            throw new NotImplementedException("Need to update values");
+
             var blobClient = await GetBlobClientAsync(absoluteFilePath);
             var blobProperties = await blobClient.GetPropertiesAsync() ?? throw new DataNotFoundException($"File not found: {absoluteFilePath}");
             var file = new FileMetdataBase
             {
-                FullPath = blobPath.Path, // full path of the file
-                FullDirectoryPath = directoryPath,
                 FileName = blobPath.Path.Substring(blobClient.Name.LastIndexOf('/') + 1), // file name
                 Size = blobProperties.Value.ContentLength, // size in bytes
                 LastModified = blobProperties.Value.LastModified // last modified date

--- a/src/AsYouLikeit.FileProvider/Services/AzureBlobFileService.cs
+++ b/src/AsYouLikeit.FileProvider/Services/AzureBlobFileService.cs
@@ -107,8 +107,8 @@ namespace AsYouLikeIt.FileProviders.Services
                     {
                         FullPath = Format.PathMergeForwardSlashes(blobPath.ContainerName, blobPath.Path, fileName), // full path of the file
                         FullDirectoryPath = Format.PathMergeForwardSlashes(blobPath.ContainerName, blobPath.Path),//Format.PathMergeForwardSlashes( blobPath. blobHierarchyItem.Blob.Name.Substring(0, blobHierarchyItem.Blob.Name.LastIndexOf('/')).StripAllLeadingAndTrailingSlashes(), // directory path
-                        RelativeDirectoryPath = Format.PathMergeForwardSlashes(blobPath.ContainerName, blobPath.Path), // relative directory path from the base directory (for display/storage purposes)
-                        RelativeFilePath = Format.PathMergeForwardSlashes(blobPath.ContainerName, blobPath.Path, fileName),
+                        AbsoluteDirectoryPath = Format.PathMergeForwardSlashes(blobPath.ContainerName, blobPath.Path), // relative directory path from the base directory (for display/storage purposes)
+                        AbsoluteFilePath = Format.PathMergeForwardSlashes(blobPath.ContainerName, blobPath.Path, fileName),
                         FileName = fileName,
                         Size = blobHierarchyItem.Blob.Properties.ContentLength ?? 0, // size in bytes
                         LastModified = blobHierarchyItem.Blob.Properties.LastModified ?? DateTimeOffset.UtcNow, // last modified date

--- a/src/AsYouLikeit.FileProvider/Services/AzureBlobFileService.cs
+++ b/src/AsYouLikeit.FileProvider/Services/AzureBlobFileService.cs
@@ -102,14 +102,18 @@ namespace AsYouLikeIt.FileProviders.Services
             {
                 if (!blobHierarchyItem.IsPrefix)
                 {
+
+                    throw new NotImplementedException("Add relative and full paths to metadata");
+
                     var fileName = blobHierarchyItem.Blob.Name.Substring(blobPath.Path.Length).StripAllLeadingAndTrailingSlashes();
                     var file = new FileMetdataBase
                     {
                         FullPath = Format.PathMergeForwardSlashes(blobPath.ContainerName, blobPath.Path, fileName), // full path of the file
-                        DirectoryPath = blobPath.Path,//Format.PathMergeForwardSlashes( blobPath. blobHierarchyItem.Blob.Name.Substring(0, blobHierarchyItem.Blob.Name.LastIndexOf('/')).StripAllLeadingAndTrailingSlashes(), // directory path
+                        FullDirectoryPath = blobPath.Path,//Format.PathMergeForwardSlashes( blobPath. blobHierarchyItem.Blob.Name.Substring(0, blobHierarchyItem.Blob.Name.LastIndexOf('/')).StripAllLeadingAndTrailingSlashes(), // directory path
                         FileName = blobHierarchyItem.Blob.Name.Substring(blobPath.Path.Length).StripAllLeadingAndTrailingSlashes(), // file name
                         Size = blobHierarchyItem.Blob.Properties.ContentLength ?? 0, // size in bytes
-                        LastModified = blobHierarchyItem.Blob.Properties.LastModified ?? DateTimeOffset.UtcNow // last modified date
+                        LastModified = blobHierarchyItem.Blob.Properties.LastModified ?? DateTimeOffset.UtcNow, // last modified date
+                         Extension = GetFileExtenstion(blobHierarchyItem.Blob.Name.Substring(blobPath.Path.Length).StripAllLeadingAndTrailingSlashes()) // file extension
                     };
                     files.Add(file);
                 }
@@ -120,6 +124,10 @@ namespace AsYouLikeIt.FileProviders.Services
 
         public async Task<IFileMetadata> GetFileMetadataAsync(string absoluteFilePath)
         {
+
+
+            throw new NotImplementedException("Add relative and full paths to metadata");
+
             var blobPath = this.GetBlobPath(absoluteFilePath, rootPathIsOk: true);
 
             var blobClient = await GetBlobClientAsync(absoluteFilePath);
@@ -127,7 +135,7 @@ namespace AsYouLikeIt.FileProviders.Services
             var file = new FileMetdataBase
             {
                 FullPath = blobPath.Path, // full path of the file
-                DirectoryPath = blobPath.Path.Substring(0, blobClient.Name.LastIndexOf('/')).StripAllLeadingAndTrailingSlashes(), // directory path
+                FullDirectoryPath = blobPath.Path.Substring(0, blobClient.Name.LastIndexOf('/')).StripAllLeadingAndTrailingSlashes(), // directory path
                 FileName = blobPath.Path.Substring(blobClient.Name.LastIndexOf('/') + 1), // file name
                 Size = blobProperties.Value.ContentLength, // size in bytes
                 LastModified = blobProperties.Value.LastModified // last modified date
@@ -261,6 +269,20 @@ namespace AsYouLikeIt.FileProviders.Services
             }
 
             return new BlobPath() { ContainerName = segments.First(), Path = Format.PathMergeForwardSlashes(segments.Skip(1).ToArray()), OriginalPathCase = absoluteFilePath, OriginalFileNameCase = originalFileName };
+        }
+
+        private string GetFileExtenstion(string fileName)
+        {
+            if (string.IsNullOrEmpty(fileName))
+            {
+                return string.Empty;
+            }
+            var lastDotIndex = fileName.LastIndexOf('.');
+            if (lastDotIndex < 0 || lastDotIndex == fileName.Length - 1)
+            {
+                return string.Empty; // No extension found
+            }
+            return fileName.Substring(lastDotIndex)?.ToLowerInvariant();
         }
 
         private struct BlobPath

--- a/src/AsYouLikeit.FileProvider/Services/FileSystemService.cs
+++ b/src/AsYouLikeit.FileProvider/Services/FileSystemService.cs
@@ -71,9 +71,7 @@ namespace AsYouLikeIt.FileProviders.Services
         {
             var fileSystemPath = GetFilePath(absoluteDirectoryPath);
             var dir = new DirectoryInfo(fileSystemPath);
-
             var files = new List<IFileMetadata>();
-
             if (dir.Exists)
             {
                 var fileInfos = dir.GetFiles();
@@ -81,8 +79,6 @@ namespace AsYouLikeIt.FileProviders.Services
                 {
                     var file = new FileMetdataBase
                     {
-                        FullPath = f.FullName, // full path of the file
-                        FullDirectoryPath = f.Directory?.FullName, // directory path
                         AbsoluteDirectoryPath = GetAbsolutePath(f.Directory?.FullName), // absolute directory path for display/storage purposes, e.g. "/content/uploads"
                         AbsoluteFilePath = GetAbsolutePath(f.FullName), // absolute file path for display/storage purposes, e.g. "/content/uploads/myfile.txt"
                         FileName = f.Name, // file name
@@ -90,10 +86,12 @@ namespace AsYouLikeIt.FileProviders.Services
                         Size = f.Length, // size in bytes
                         LastModified = new DateTimeOffset(f.LastWriteTimeUtc, TimeSpan.Zero) // last modified date
                     };
+                    file.Metadata ??= new Dictionary<string, string>(StringComparer.Ordinal); // ensure the metadata dictionary is initialized
+                    file.Metadata["FullPath"] = f.FullName; // ensure we have the full path in the metadata for consistency
+                    file.Metadata["FullDirectoryPath"] = f.Directory?.FullName; // add the directory path to the metadata for reference
                     files.Add(file);
                 }
             }
-
             return Task.FromResult(files);
         }
 
@@ -104,12 +102,9 @@ namespace AsYouLikeIt.FileProviders.Services
             {
                 throw new DataNotFoundException($"File not found: {fileSystemPath}");
             }
-
             var f = new FileInfo(fileSystemPath);
             var file = new FileMetdataBase
             {
-                FullPath = f.FullName, // full path of the file
-                FullDirectoryPath = f.Directory?.FullName, // directory path
                 AbsoluteDirectoryPath = GetAbsolutePath(f.Directory?.FullName), // absolute directory path for display/storage purposes, e.g. "/content/uploads"
                 AbsoluteFilePath = GetAbsolutePath(f.FullName), // absolute file path for display/storage purposes, e.g. "/content/uploads/myfile.txt"
                 FileName = f.Name, // file name
@@ -117,6 +112,9 @@ namespace AsYouLikeIt.FileProviders.Services
                 Size = f.Length, // size in bytes
                 LastModified = new DateTimeOffset(f.LastWriteTimeUtc, TimeSpan.Zero) // last modified date
             };
+            file.Metadata ??= new Dictionary<string, string>(StringComparer.Ordinal); // ensure the metadata dictionary is initialized
+            file.Metadata["FullPath"] = f.FullName; // ensure we have the full path in the metadata for consistency
+            file.Metadata["FullDirectoryPath"] = f.Directory?.FullName; // add the directory path to the metadata for reference
             return Task.FromResult<IFileMetadata>(file);
         }
 

--- a/src/AsYouLikeit.FileProvider/Services/FileSystemService.cs
+++ b/src/AsYouLikeit.FileProvider/Services/FileSystemService.cs
@@ -79,10 +79,13 @@ namespace AsYouLikeIt.FileProviders.Services
                 var fileInfos = dir.GetFiles();
                 foreach (var f in fileInfos)
                 {
+
+                    throw new NotImplementedException("Add relative and full paths to metadata");
+
                     var file = new FileMetdataBase
                     {
                         FullPath = f.FullName, // full path of the file
-                        DirectoryPath = f.Directory?.FullName, // directory path
+                        FullDirectoryPath = f.Directory?.FullName, // directory path
                         FileName = f.Name, // file name
                         Size = f.Length, // size in bytes
                         LastModified = new DateTimeOffset(f.LastWriteTimeUtc, TimeSpan.Zero) // last modified date
@@ -101,11 +104,15 @@ namespace AsYouLikeIt.FileProviders.Services
             {
                 throw new DataNotFoundException($"File not found: {fileSystemPath}");
             }
+
+            throw new NotImplementedException("Add relative and full paths to metadata");
+
             var f = new FileInfo(fileSystemPath);
+           
             var file = new FileMetdataBase
             {
                 FullPath = f.FullName, // full path of the file
-                DirectoryPath = f.Directory?.FullName, // directory path
+                FullDirectoryPath = f.Directory?.FullName, // directory path
                 FileName = f.Name, // file name
                 Size = f.Length, // size in bytes
                 LastModified = new DateTimeOffset(f.LastWriteTimeUtc, TimeSpan.Zero) // last modified date

--- a/src/AsYouLikeit.FileProvider/Services/IFileService.cs
+++ b/src/AsYouLikeit.FileProvider/Services/IFileService.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using AsYouLikeit.FileProviders;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -13,6 +14,10 @@ namespace AsYouLikeIt.FileProviders.Services
         Task<List<string>> ListSubDirectoriesAsync(string absoluteDirectoryPath);
 
         Task<List<string>> ListFilesAsync(string absoluteDirectoryPath);
+
+        Task<List<IFileMetadata>> ListFilesWithMetadataAsync(string absoluteDirectoryPath);
+
+        Task<IFileMetadata> GetFileMetadataAsync(string absoluteFilePath);
 
         Task DeleteDirectoryAndContentsAsync(string absoluteDirectoryPath);
 


### PR DESCRIPTION
This pull request introduces several new features and improvements to the `AsYouLikeit.FileProvider` project, focusing on file metadata handling and enhancing existing file service functionalities. The most important changes include adding support for listing and retrieving file metadata, updating versioning, and fixing a typo in a property name.

### New Features:
* [`src/AsYouLikeit.FileProvider/Services/AzureBlobFileService.cs`](diffhunk://#diff-8d8a8e5907a69eba8f44ccf2db3c6ab30efb838ba6c8b05998a60196f565a226L83-R158): Added methods `ListFilesWithMetadataAsync` and `GetFileMetadataAsync` to list files with metadata and retrieve metadata for a specific file. [[1]](diffhunk://#diff-8d8a8e5907a69eba8f44ccf2db3c6ab30efb838ba6c8b05998a60196f565a226L83-R158) [[2]](diffhunk://#diff-8d8a8e5907a69eba8f44ccf2db3c6ab30efb838ba6c8b05998a60196f565a226R287-R309)
* [`src/AsYouLikeit.FileProvider/Services/FileSystemService.cs`](diffhunk://#diff-81a217199ac420ea5a3ca646a6ca9818aa6b703ce09da9647b22412855cd6759R70-R121): Added methods `ListFilesWithMetadataAsync` and `GetFileMetadataAsync` to list files with metadata and retrieve metadata for a specific file. [[1]](diffhunk://#diff-81a217199ac420ea5a3ca646a6ca9818aa6b703ce09da9647b22412855cd6759R70-R121) [[2]](diffhunk://#diff-81a217199ac420ea5a3ca646a6ca9818aa6b703ce09da9647b22412855cd6759R195-R215)

### Codebase Improvements:
* [`src/AsYouLikeit.FileProvider/FileMetdataBase.cs`](diffhunk://#diff-1e61ebdd51738b044baf44a2d53a983a0ee90a15ac00d9503a1e64eba8424093R1-R23): Introduced the `FileMetdataBase` class implementing `IFileMetadata` interface to represent file metadata.
* [`src/AsYouLikeit.FileProvider/IFileMetadata.cs`](diffhunk://#diff-087883f0290816c6ddfeed7c1222ff6d4cd1bcd3ed14dc053c52bcf23d05f19aR1-R46): Added `IFileMetadata` interface to define the structure of file metadata.

### Versioning and Documentation:
* [`src/AsYouLikeit.FileProvider/AsYouLikeit.FileProviders.csproj`](diffhunk://#diff-da8464ce8efffc653bcb5b019c38656456541fd1cc690ee5370de87f3faba695L12-R12): Updated the `VersionPrefix` to `1.2.3.0-beta` and added a description for listing file metadata in a directory. [[1]](diffhunk://#diff-da8464ce8efffc653bcb5b019c38656456541fd1cc690ee5370de87f3faba695L12-R12) [[2]](diffhunk://#diff-da8464ce8efffc653bcb5b019c38656456541fd1cc690ee5370de87f3faba695R21)

### Bug Fixes:
* [`src/AsYouLikeit.FileProvider/EnvironmentContext.cs`](diffhunk://#diff-93b570f1deb112981a4b5ae4c580c68367fbca496f2baa62cf8c9ec4ef1f3b30L8-R8): Corrected the property name from `UseForwardSlashed` to `UseForwardSlashes`.

### Tests:
* [`src/AsYouLikeIt.FileProvider.Tests/FileServiceTest.cs`](diffhunk://#diff-625cfdee3f49bec2945de22f82f52edcda58df3d797f27bf10be3d83b7b7f7ddR327-R408): Added a new test method `TestFileMetadataAsync` to verify file metadata functionality.