### PR TITLE
Feature  steam with buffer

### DIFF
--- a/src/AsYouLikeIt.FileProvider.Tests/FileServiceTest.cs
+++ b/src/AsYouLikeIt.FileProvider.Tests/FileServiceTest.cs
@@ -311,6 +311,24 @@ namespace AsYouLikeIt.FileProvider.Tests
         }
 
         [Fact]
+        public async Task TestLargeStreamWrite()
+        {
+            // Create a large byte array
+            var largeBytes = GenerateRandomBytes(1024 * 1024 * 50); // 50 MB
+            // create a stream
+            using (var stream = new MemoryStream(largeBytes))
+            {
+                var filePath = $"{TEST_CONTAINER_NAME}/TestLargeStreamWrite/largefile.bin";
+                await _fileService.WriteStreamAsync(filePath, stream);
+                Assert.True(await _fileService.ExistsAsync(filePath));
+                var contents = await _fileService.ReadAllBytesAsync(filePath);
+                Assert.True(largeBytes.SequenceEqual(contents));
+                await _fileService.DeleteAsync(filePath);
+            }
+        }
+
+
+        [Fact]
         public async Task TestRootDirectoryFiles()
         {
             var bytes1 = GenerateRandomBytes();

--- a/src/AsYouLikeit.FileProvider/AsYouLikeit.FileProviders.csproj
+++ b/src/AsYouLikeit.FileProvider/AsYouLikeit.FileProviders.csproj
@@ -9,7 +9,7 @@
 		<Copyright>Copyright © $([System.DateTime]::Now.Year)</Copyright>
 		<Trademark></Trademark>
 		<Product>$(Title)</Product>
-		<VersionPrefix>1.2.3.1-beta</VersionPrefix>
+		<VersionPrefix>1.2.4.0-beta</VersionPrefix>
 		<Description>
 			Provides DI for multiple file providers allowing applications to access files from virtual locations.
 			Can be extended to add implementations for AWS and other cloud providers.
@@ -19,6 +19,7 @@
 			- Azure Blob Storage
 			- List file names in a directory
 			- List file metadata in a directory
+			- Add write with buffer from a stream
 		</Description>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<PackageProjectUrl></PackageProjectUrl>

--- a/src/AsYouLikeit.FileProvider/FileMetdataBase.cs
+++ b/src/AsYouLikeit.FileProvider/FileMetdataBase.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace AsYouLikeit.FileProviders
+namespace AsYouLikeIt.FileProviders
 {
     public partial class FileMetdataBase : IFileMetadata
     {

--- a/src/AsYouLikeit.FileProvider/IFileMetadata.cs
+++ b/src/AsYouLikeit.FileProvider/IFileMetadata.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using Metadata = System.Collections.Generic.IDictionary<string, string>;
 
-namespace AsYouLikeit.FileProviders
+namespace AsYouLikeIt.FileProviders
 {
     public interface IFileMetadata
     {

--- a/src/AsYouLikeit.FileProvider/Services/AzureBlobFileService.cs
+++ b/src/AsYouLikeit.FileProvider/Services/AzureBlobFileService.cs
@@ -1,5 +1,4 @@
-﻿using AsYouLikeit.FileProviders;
-using AsYouLikeIt.Sdk.Common.Exceptions;
+﻿using AsYouLikeIt.Sdk.Common.Exceptions;
 using AsYouLikeIt.Sdk.Common.Extensions;
 using AsYouLikeIt.Sdk.Common.Utilities;
 using Azure.Storage.Blobs;
@@ -10,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -166,10 +166,26 @@ namespace AsYouLikeIt.FileProviders.Services
         public async Task WriteAllBytesAsync(string absoluteFilePath, IEnumerable<byte> data)
         {
             var blobClientAndBlobPath = await GetBlobClientAndBlobPathAsync(absoluteFilePath);
-            using (var stream = new MemoryStream(data.ToArray()))
+
+            byte[] checksum;
+            using (var md5 = MD5.Create())
             {
-                await blobClientAndBlobPath.BlobClient.UploadAsync(stream, overwrite: true);
+                using (var stream = new MemoryStream(data.ToArray()))
+                {
+                    checksum = md5.ComputeHash(stream);
+                    stream.Position = 0; // Reset the stream position for upload
+                    await blobClientAndBlobPath.BlobClient.UploadAsync(stream, overwrite: true);
+                }
             }
+
+            // Set the MD5 ContentHash in the blob's HTTP headers
+            var blobHttpHeaders = new BlobHttpHeaders
+            {
+                ContentHash = checksum
+            };
+            await blobClientAndBlobPath.BlobClient.SetHttpHeadersAsync(blobHttpHeaders);
+
+            // Set additional metadata
             var metadata = new Dictionary<string, string>
             {
                 { "absoluteFilePath", absoluteFilePath },
@@ -182,6 +198,76 @@ namespace AsYouLikeIt.FileProviders.Services
         {
             var data = Encoding.UTF8.GetBytes(content);
             return WriteAllBytesAsync(absoluteFilePath, data);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="absoluteFilePath"></param>
+        /// <param name="stream"></param>
+        /// <param name="chunkSize">Default of 4 MB</param>
+        /// <returns></returns>
+        public async Task WriteStreamAsync(string absoluteFilePath, Stream stream, int bufferSize = 4 * 1024 * 1024)
+        {
+            var blockBlobClient = await GetBlockBlobClientAsync(absoluteFilePath, true);
+
+            var blockList = new List<string>();
+            int blockId = 0;
+            byte[] buffer = new byte[bufferSize];
+            int bytesRead;
+            long totalBytesRead = 0;
+
+            long totalBytes = 0;
+
+            if (stream.CanSeek)
+            {
+                totalBytes = stream.Length;
+                _logger.LogDebug($"WriteStreamAsync '{absoluteFilePath}' - stream length: {totalBytes}");
+            }
+            else
+            {
+                _logger.LogDebug($"WriteStreamAsync '{absoluteFilePath}' - stream does not support length");
+            }
+            byte[] hash = null;
+            using (var md5 = MD5.Create())
+            {
+                while ((bytesRead = await stream.ReadAsync(buffer, 0, buffer.Length)) > 0)
+                {
+                    using (var chunkStream = new MemoryStream(buffer, 0, bytesRead))
+                    {
+                        string blockIdBase64 = Convert.ToBase64String(BitConverter.GetBytes(blockId));
+                        await blockBlobClient.StageBlockAsync(blockIdBase64, chunkStream);
+                        blockList.Add(blockIdBase64);
+                        blockId++;
+
+                        totalBytesRead += bytesRead;
+
+                        if (totalBytes > 0)
+                        {
+                            _logger.LogInformation($"Uploaded {bytesRead} bytes of {absoluteFilePath} to blob storage. {(double)totalBytesRead / totalBytes:P2}% complete.");
+                        }
+                        else
+                        {
+                            _logger.LogInformation($"Uploaded {bytesRead} bytes of {absoluteFilePath} to blob storage.");
+                        }
+
+                        // Update MD5 hash
+                        md5.TransformBlock(buffer, 0, bytesRead, null, 0);
+                    }
+                }
+                md5.TransformFinalBlock(buffer, 0, 0);
+                hash = md5.Hash;
+            }
+
+            await blockBlobClient.CommitBlockListAsync(blockList);
+           _logger.LogInformation($"Completed upload of {absoluteFilePath} to blob storage.");
+
+            // Set the MD5 hash in the blob properties
+            var blobHttpHeaders = new BlobHttpHeaders
+            {
+                ContentHash = hash
+            };
+            await blockBlobClient.SetHttpHeadersAsync(blobHttpHeaders);
         }
 
         public async Task<Stream> GetStreamAsync(string absoluteFilePath)
@@ -261,6 +347,16 @@ namespace AsYouLikeIt.FileProviders.Services
 
             var blobClient = blobContainerClient.GetBlobClient(blobPath.Path);
             return (blobClient, blobPath);
+        }
+
+        private async Task<BlockBlobClient> GetBlockBlobClientAsync(string absolutePath, bool rootPathIsOk = false)
+        {
+            var blobPath = GetBlobPath(absolutePath);
+
+            var blobContainerClient = new BlobContainerClient(_connString, blobPath.ContainerName);
+            await blobContainerClient.CreateIfNotExistsAsync(PublicAccessType.None);
+
+            return blobContainerClient.GetBlockBlobClient(blobPath.Path);
         }
 
         private async Task<BlobClient> GetBlobClientAsync(string absolutePath) => (await GetBlobClientAndBlobPathAsync(absolutePath)).BlobClient;

--- a/src/AsYouLikeit.FileProvider/Services/FileSystemService.cs
+++ b/src/AsYouLikeit.FileProvider/Services/FileSystemService.cs
@@ -1,5 +1,4 @@
-﻿using AsYouLikeIt.FileProviders;
-using AsYouLikeIt.Sdk.Common.Exceptions;
+﻿using AsYouLikeIt.Sdk.Common.Exceptions;
 using AsYouLikeIt.Sdk.Common.Extensions;
 using AsYouLikeIt.Sdk.Common.Utilities;
 using Microsoft.Extensions.Logging;

--- a/src/AsYouLikeit.FileProvider/Services/FileSystemService.cs
+++ b/src/AsYouLikeit.FileProvider/Services/FileSystemService.cs
@@ -1,4 +1,4 @@
-﻿using AsYouLikeit.FileProviders;
+﻿using AsYouLikeIt.FileProviders;
 using AsYouLikeIt.Sdk.Common.Exceptions;
 using AsYouLikeIt.Sdk.Common.Extensions;
 using AsYouLikeIt.Sdk.Common.Utilities;
@@ -147,7 +147,35 @@ namespace AsYouLikeIt.FileProviders.Services
             return File.WriteAllBytesAsync(fileSystemPath, data.ToArray());
         }
 
-        public Task WriteAllTextAsync(string absoluteFilePath, string contents)
+        public async Task WriteStreamAsync(string absoluteFilePath, Stream stream, int bufferSize = 4 * 1024 * 1024)
+        {
+			long totalBytes = 0;
+
+			if (stream.CanSeek)
+			{
+				totalBytes = stream.Length;
+				_logger.LogDebug($"WriteStreamAsync '{absoluteFilePath}' - stream length: {totalBytes}");
+			}
+			else
+			{
+				_logger.LogDebug($"WriteStreamAsync '{absoluteFilePath}' - stream does not support length");
+			}
+
+			var fileSystemPath = GetFilePath(absoluteFilePath);
+			var fileInfo = new FileInfo(fileSystemPath);
+			if (fileSystemPath != null && !fileInfo.Directory.Exists)
+			{
+				Directory.CreateDirectory(fileInfo.Directory.FullName);
+			}
+			using (var fileStream = new FileStream(fileSystemPath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize, FileOptions.SequentialScan))
+			{
+				await stream.CopyToAsync(fileStream);
+			}
+			_logger.LogInformation($"Completed upload of {absoluteFilePath} to file system.");
+		}
+
+
+		public Task WriteAllTextAsync(string absoluteFilePath, string contents)
         {
             var fileSystemPath = GetFilePath(absoluteFilePath);
             var fileInfo = new FileInfo(fileSystemPath);

--- a/src/AsYouLikeit.FileProvider/Services/IFileService.cs
+++ b/src/AsYouLikeit.FileProvider/Services/IFileService.cs
@@ -1,4 +1,4 @@
-﻿using AsYouLikeit.FileProviders;
+﻿using AsYouLikeIt.FileProviders;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -28,6 +28,15 @@ namespace AsYouLikeIt.FileProviders.Services
         Task<Stream> GetStreamAsync(string absoluteFilePath);
 
         Task WriteAllBytesAsync(string absoluteFilePath, IEnumerable<byte> data);
+
+        /// <summary>
+        /// Uses a stream and buffer to stream the file in chunks.
+        /// </summary>
+        /// <param name="absoluteFilePath"></param>
+        /// <param name="stream"></param>
+        /// <param name="bufferSize">Defaults to 4 MB</param>
+        /// <returns></returns>
+        Task WriteStreamAsync(string absoluteFilePath, Stream stream, int bufferSize = 4 * 1024 * 1024);
 
         Task WriteAllTextAsync(string absoluteFilePath, string content);
 


### PR DESCRIPTION
This pull request includes several changes to the `AsYouLikeIt.FileProvider` project, focusing on adding new functionality for writing streams, updating versioning, and fixing namespace casing. The most important changes are listed below:

### New Functionality:
* Added `WriteStreamAsync` method to `AzureBlobFileService` and `FileSystemService` to support writing large files in chunks using a buffer. This includes setting MD5 hash for integrity verification. [[1]](diffhunk://#diff-8d8a8e5907a69eba8f44ccf2db3c6ab30efb838ba6c8b05998a60196f565a226R205-R274) [[2]](diffhunk://#diff-81a217199ac420ea5a3ca646a6ca9818aa6b703ce09da9647b22412855cd6759R149-R176)
* Updated `IFileService` interface to include the new `WriteStreamAsync` method.

### Testing:
* Added a new test `TestLargeStreamWrite` in `FileServiceTest.cs` to verify the functionality of writing and reading large streams.

### Versioning:
* Updated the `VersionPrefix` in `AsYouLikeit.FileProviders.csproj` from `1.2.3.1-beta` to `1.2.4.0-beta`.

### Documentation:
* Updated the project description in `AsYouLikeit.FileProviders.csproj` to mention the new stream writing functionality.

### Namespace Fixes:
* Corrected the casing of the namespace from `AsYouLikeit.FileProviders` to `AsYouLikeIt.FileProviders` in multiple files. [[1]](diffhunk://#diff-1e61ebdd51738b044baf44a2d53a983a0ee90a15ac00d9503a1e64eba8424093L5-R5) [[2]](diffhunk://#diff-087883f0290816c6ddfeed7c1222ff6d4cd1bcd3ed14dc053c52bcf23d05f19aL6-R6) [[3]](diffhunk://#diff-8d8a8e5907a69eba8f44ccf2db3c6ab30efb838ba6c8b05998a60196f565a226L1-R1) [[4]](diffhunk://#diff-81a217199ac420ea5a3ca646a6ca9818aa6b703ce09da9647b22412855cd6759L1-R1) [[5]](diffhunk://#diff-8b20fc7cf9ca622c00f0a3987377e4296ac1fc2dd18886301f7381206761d092L1-R1)